### PR TITLE
Potential fix for code scanning alert no. 2: Unused variable, import, function or class

### DIFF
--- a/__tests__/registry-client.test.ts
+++ b/__tests__/registry-client.test.ts
@@ -80,7 +80,7 @@ describe('RegistryClient', () => {
         return mockRequest as any;
       });
 
-      const result = await registryClient.getPackagesPublishDates(packages);
+      await registryClient.getPackagesPublishDates(packages);
 
       expect(mockHttps.get).toHaveBeenCalledWith(
         expect.stringContaining('lodash'),


### PR DESCRIPTION
Potential fix for [https://github.com/josepderiu/npm-minimum-age-validation/security/code-scanning/2](https://github.com/josepderiu/npm-minimum-age-validation/security/code-scanning/2)

The best way to fix this problem is to remove the declaration of the unused variable `result` on line 83 of the file `__tests__/registry-client.test.ts`. Since there is no subsequent usage of this variable, and the awaited call doesn't have side-effects that require waiting or storing, the line can be replaced with simply awaiting the function (for clarity that the async execution completes), or even omitted entirely if not required for the test. Double-check that the absence of this line does not affect the test's intent (which, looking at the surrounding code, it does not).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
